### PR TITLE
Choice pointers

### DIFF
--- a/genGo.go
+++ b/genGo.go
@@ -201,6 +201,9 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
+			if attribute.Optional && !strings.HasPrefix(fieldType, `*`) {
+				fieldType = "*" + fieldType
+			}
 			content += fmt.Sprintf("\t%sAttr\t%s\t`xml:\"%s,attr%s\"`\n", genGoFieldName(attribute.Name, false), fieldType, attribute.Name, optional)
 		}
 		for _, group := range v.Groups {

--- a/genGo.go
+++ b/genGo.go
@@ -224,6 +224,9 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
+			if element.Optional && !strings.HasPrefix(fieldType, `*`) {
+				fieldType = "*" + fieldType
+			}
 			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name, optional)
 		}
 		if len(v.Base) > 0 {

--- a/genGo.go
+++ b/genGo.go
@@ -227,7 +227,7 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
-			if element.Optional && !strings.HasPrefix(fieldType, `*`) {
+			if element.Optional && !element.Plural && !strings.HasPrefix(fieldType, `*`) {
 				fieldType = "*" + fieldType
 			}
 			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name, optional)

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -18,6 +18,7 @@ typedef struct {
 	char Title;
 	char Blob[];
 	char Timestamp;
+	char Metadata;
 } MyType4;
 
 // MyType5 ...

--- a/test/c/base64.xsd.h
+++ b/test/c/base64.xsd.h
@@ -53,7 +53,7 @@ typedef struct {
 // TopLevel ...
 typedef struct {
 	float CostAttr; // attr, optional
-	char LastUpdatedAttr; // attr, optional
+	char LastUpdatedAttr; // attr
 	MyType7 Nested;
 	char MyType1[];
 	MyType2 MyType2[];

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -12,14 +12,14 @@ type MyType1 string
 // MyType2 ...
 type MyType2 struct {
 	XMLName    xml.Name `xml:"myType2"`
-	LengthAttr int      `xml:"length,attr,omitempty"`
+	LengthAttr *int     `xml:"length,attr,omitempty"`
 	Value      string   `xml:",chardata"`
 }
 
 // MyType3 ...
 type MyType3 struct {
 	XMLName    xml.Name `xml:"myType3"`
-	LengthAttr int      `xml:"length,attr,omitempty"`
+	LengthAttr *int     `xml:"length,attr,omitempty"`
 	Value      string   `xml:",chardata"`
 }
 
@@ -37,8 +37,8 @@ type MyType5 string
 
 // MyType6 ...
 type MyType6 struct {
-	CodeAttr       string `xml:"code,attr,omitempty"`
-	IdentifierAttr int    `xml:"identifier,attr,omitempty"`
+	CodeAttr       *string `xml:"code,attr,omitempty"`
+	IdentifierAttr *int    `xml:"identifier,attr,omitempty"`
 }
 
 // MyType7 ...
@@ -64,8 +64,8 @@ type MyType10 struct {
 
 // TopLevel ...
 type TopLevel struct {
-	CostAttr        float64    `xml:"cost,attr,omitempty"`
-	LastUpdatedAttr string     `xml:"LastUpdated,attr,omitempty"`
+	CostAttr        *float64   `xml:"cost,attr,omitempty"`
+	LastUpdatedAttr string     `xml:"LastUpdated,attr"`
 	Nested          *MyType7   `xml:"nested,omitempty"`
 	MyType1         []string   `xml:"myType1"`
 	MyType2         []*MyType2 `xml:"myType2"`

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -29,6 +29,7 @@ type MyType4 struct {
 	Title     string   `xml:"title"`
 	Blob      string   `xml:"blob"`
 	Timestamp string   `xml:"timestamp"`
+	Metadata  *string  `xml:"metadata,omitempty"`
 }
 
 // MyType5 ...

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -67,7 +67,7 @@ type TopLevel struct {
 	CostAttr        *float64   `xml:"cost,attr,omitempty"`
 	LastUpdatedAttr string     `xml:"LastUpdated,attr"`
 	Nested          *MyType7   `xml:"nested,omitempty"`
-	MyType1         []string   `xml:"myType1"`
-	MyType2         []*MyType2 `xml:"myType2"`
+	MyType1         []string   `xml:"myType1,omitempty"`
+	MyType2         []*MyType2 `xml:"myType2,omitempty"`
 	*MyType6
 }

--- a/test/java/base64.xsd.java
+++ b/test/java/base64.xsd.java
@@ -92,7 +92,7 @@ public class MyType10 {
 public class TopLevel extends MyType6  {
 	@XmlAttribute(name = "cost")
 	protected Float CostAttr;
-	@XmlAttribute(name = "LastUpdated")
+	@XmlAttribute(name = "LastUpdated", required = true)
 	protected String LastUpdatedAttr;
 	@XmlElement(required = true, name = "nested")
 	protected MyType7 Nested;

--- a/test/java/base64.xsd.java
+++ b/test/java/base64.xsd.java
@@ -43,6 +43,8 @@ public class MyType4 {
 	protected List<Byte> Blob;
 	@XmlElement(required = true, name = "timestamp")
 	protected String Timestamp;
+	@XmlElement(required = true, name = "metadata")
+	protected String Metadata;
 }
 
 // MyType5 ...

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -43,6 +43,8 @@ pub struct MyType4 {
 	pub blob: String,
 	#[serde(rename = "timestamp")]
 	pub timestamp: u8,
+	#[serde(rename = "metadata")]
+	pub metadata: Option<String>,
 }
 
 

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -106,7 +106,7 @@ pub struct TopLevel {
 	#[serde(rename = "cost")]
 	pub cost: Option<f64>,
 	#[serde(rename = "LastUpdated")]
-	pub last_updated: Option<u8>,
+	pub last_updated: u8,
 	#[serde(rename = "nested")]
 	pub nested: Option<MyType7>,
 	#[serde(rename = "myType1")]

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -20,6 +20,7 @@ export class MyType4 {
 	Title: string;
 	Blob: Uint8Array;
 	Timestamp: string;
+	Metadata: string;
 }
 
 // MyType5 ...

--- a/test/ts/base64.xsd.ts
+++ b/test/ts/base64.xsd.ts
@@ -56,7 +56,7 @@ export class MyType10 {
 // TopLevel ...
 export class TopLevel extends MyType6  {
 	CostAttr: number | null;
-	LastUpdatedAttr: string | null;
+	LastUpdatedAttr: string;
 	Nested: MyType7;
 	MyType1: Uint8Array;
 	MyType2: Array<MyType2>;

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -26,6 +26,7 @@
       <element name="title" type="string"/>
       <element name="blob" type="base64Binary"/>
       <element name="timestamp" type="dateTime"/>
+      <element name="metadata" type="string" minOccurs="0" />
     </sequence>
   </complexType>
 

--- a/test/xsd/base64.xsd
+++ b/test/xsd/base64.xsd
@@ -84,7 +84,7 @@
             </choice>
           </sequence>
           <attribute name="cost" type="double"/>
-          <attribute name="LastUpdated" type="dateTime"/>
+          <attribute name="LastUpdated" type="dateTime" use="required"/>
         </extension>
       </complexContent>
     </complexType>

--- a/xmlElement.go
+++ b/xmlElement.go
@@ -74,6 +74,7 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 	}
 
 	if opt.Choice.Len() > 0 {
+		e.Optional = true
 		e.Plural = e.Plural || opt.Choice.Peek().(*Choice).Plural
 	}
 


### PR DESCRIPTION
# PR Details

## Description
This PR ensures that elements in choices are optional. Additionally, it change Go code generation so that struct fields that are both optional and plural have type `[]T` rather than `[]*T` the field was not already designated as a pointer.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
